### PR TITLE
FIX: composer tied to outdated version of betterbuttons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "silverstripe/framework": "~3.1",
-        "unclecheese/betterbuttons": "1.2.6"
+        "unclecheese/betterbuttons": "*"
     }
     
 }


### PR DESCRIPTION
Composer is conflicting on installs, as other modules require a different better button version.
