### PR TITLE
Display all data from object & design adjustments

### DIFF
--- a/code/VersionViewerDataObject.php
+++ b/code/VersionViewerDataObject.php
@@ -103,23 +103,28 @@ class VersionViewerDataObject extends DataExtension
 				$publisher_heading = "";
 				$author_heading = "";
 
+				$up_date = new SS_Datetime('update');
+				$up_date->setValue($version->LastEdited);
+
+				$nice_date = $up_date->FormatFromSettings();
+
 				if($publishedby) {
 					$publisher_heading = " by " . $publishedby->getName();
 				}
 
 				if($authoredby) {
 					$author_heading = " <em>authored by " . $authoredby->getName() . "</em>";
+					$tab_title = $nice_date . ' <span class="history-state">' . $was_published_full .  '</span> <span class="history-author">Author: ' . $authoredby->getName() . '</span>';
+				else {
+					$author_heading = "";
+					$tab_title = $nice_date . ' <span class="history-state">' . $was_published_full .  '</span>';
 				}
 
-				$up_date = new SS_Datetime('update');
-				$up_date->setValue($version->LastEdited);
-
-				$nice_date = $up_date->FormatFromSettings();
-				$tab_title =  $nice_date . ' <span class="history-state">' . $was_published_full .  '</span> <span class="history-author">Author: ' . $authoredby ? $authoredby->getName() : 'N/A' . '</span>';
 				$latest_version_notice = "";
 				if($version->isLatestVersion()) {
 					$latest_version_notice = " (latest version)";
 				}
+
 				$tab_heading = "<div class='message notice'><p><strong>Viewing version " . $version->Version . $latest_version_notice . ".</strong><br>" . $was_published_full . $publisher_heading . " on " . $nice_date . $author_heading . "</p></div>";
 
 				// Add fields to a tab headed with a description of this version

--- a/code/VersionViewerDataObject.php
+++ b/code/VersionViewerDataObject.php
@@ -2,157 +2,157 @@
 
 class VersionViewerDataObject extends DataExtension
 {
-    public function addVersionViewer(FieldList $fields) {
-        if($this->owner->hasExtension('Versioned') || $this->owner->hasExtension('VersionedDataObject')) {
-            // Get the object where this function was called for reference purposes
-            $object = $this->owner;
+	public function addVersionViewer(FieldList $fields) {
+		if($this->owner->hasExtension('Versioned') || $this->owner->hasExtension('VersionedDataObject')) {
+			// Get the object where this function was called for reference purposes
+			$object = $this->owner;
 
-            // Get all tabs in the current model admin and prepart to put within a tabset called "Current"
-            $current_tabs = $fields->find('Name', 'Root')->Tabs();
-            $fields = FieldList::create(
-                $top = TabSet::create("Root",
-                    $currenttab = TabSet::create("Current"),
-                    $historytab = TabSet::create("History")->addExtraClass("vertical-tabs")
-                )
-            );
+			// Get all tabs in the current model admin and prepart to put within a tabset called "Current"
+			$current_tabs = $fields->find('Name', 'Root')->Tabs();
+			$fields = FieldList::create(
+				$top = TabSet::create("Root",
+					$currenttab = TabSet::create("Current"),
+					$historytab = TabSet::create("History")->addExtraClass("vertical-tabs")
+				)
+			);
 
-            $top->addExtraClass('tab-versioned');
+			$top->addExtraClass('tab-versioned');
 
-            // Add all existing tabs to "Current" tabset
-            $first = true;
-            foreach($current_tabs as $tab) {
-                // If we have the getVersionedState function,
-                // add a notice regarding the versioned state to the first tab
-                // TODO incorporate VersionedDataObjectState extension into this module
-                if($first && $object->hasMethod('getVersionedState')) {
-                    $fields->addFieldToTab("Root.Current." . $tab->title,
-                        LiteralField::create('VersionedState',
-                            '<div class="message notice"><p>' . $object->getVersionedState() . '</p></div>'
-                        )
-                    );
-                    $first = false;
-                }
-                $fields->addFieldsToTab("Root.Current." . $tab->title, $tab->Fields());
-            }
+			// Add all existing tabs to "Current" tabset
+			$first = true;
+			foreach($current_tabs as $tab) {
+				// If we have the getVersionedState function,
+				// add a notice regarding the versioned state to the first tab
+				// TODO incorporate VersionedDataObjectState extension into this module
+				if($first && $object->hasMethod('getVersionedState')) {
+					$fields->addFieldToTab("Root.Current." . $tab->title,
+						LiteralField::create('VersionedState',
+							'<div class="message notice"><p>' . $object->getVersionedState() . '</p></div>'
+						)
+					);
+					$first = false;
+				}
+				$fields->addFieldsToTab("Root.Current." . $tab->title, $tab->Fields());
+			}
 
-            // Remove any fields that have VersionViewerVisibility turned off
-            foreach($current_tabs as &$tab) {
-                foreach($tab->Fields() as $field) {
-                    // echo '<pre>'.$field->Name.' Viewable? '; print_r($field->versionViewerVisibility);
-                    if(!$field->versionViewerVisibility && $tab->fieldByName($field->Name)) {
-                        $tab->removeByName($field->Name);
-                    }
-                }
-            }
+			// Remove any fields that have VersionViewerVisibility turned off
+			foreach($current_tabs as &$tab) {
+				foreach($tab->Fields() as $field) {
+					// echo '<pre>'.$field->Name.' Viewable? '; print_r($field->versionViewerVisibility);
+					if(!$field->versionViewerVisibility && $tab->fieldByName($field->Name)) {
+						$tab->removeByName($field->Name);
+					}
+				}
+			}
 
 
-            // Also, as of now, Versioned does not track has_many or many_many relationships
-            // So find fields relating to those relationships, remove them,
-            // and add a message regarding this
-            $untracked_msg = "";
-            foreach($current_tabs as &$tab) {
-                foreach($tab->Fields() as $field) {
-                    $rel_class = $object->getRelationClass($field->Name);
-                    if($rel_class) {
-                        if(in_array($rel_class, $object->has_many()) || in_array($rel_class, $object->many_many())) {
-                            if($tab->fieldByName($field->Name)) {
-                                $tab->removeByName($field->Name);
-                                if(!$untracked_msg) {
-                                    // $untracked_msg = '<div class="message notice"><p>Note: the following relationships are not tracked by versioning because they involve multiple records:<br />';
-                                    $untracked_msg = '<p>' . $field->Title();
-                                } else {
-                                    $untracked_msg .= "<br />" . $field->Title();
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            if($untracked_msg) {
-                $untracked_msg .= '</p>';
-            }
+			// Also, as of now, Versioned does not track has_many or many_many relationships
+			// So find fields relating to those relationships, remove them,
+			// and add a message regarding this
+			$untracked_msg = "";
+			foreach($current_tabs as &$tab) {
+				foreach($tab->Fields() as $field) {
+					$rel_class = $object->getRelationClass($field->Name);
+					if($rel_class) {
+						if(in_array($rel_class, $object->has_many()) || in_array($rel_class, $object->many_many())) {
+							if($tab->fieldByName($field->Name)) {
+								$tab->removeByName($field->Name);
+								if(!$untracked_msg) {
+									// $untracked_msg = '<div class="message notice"><p>Note: the following relationships are not tracked by versioning because they involve multiple records:<br />';
+									$untracked_msg = '<p>' . $field->Title();
+								} else {
+									$untracked_msg .= "<br />" . $field->Title();
+								}
+							}
+						}
+					}
+				}
+			}
+			if($untracked_msg) {
+				$untracked_msg .= '</p>';
+			}
 
-            // Get all past versions of this data object and put the relevant data in a set of tabs
-            // within a tabset called "History"
-            $versions = $object->allVersions();
-            foreach($versions as $version) {
-                // Get a record of this version of the object
-                $record = self::get_version($object->ClassName, $object->ID, $version->Version);
+			// Get all past versions of this data object and put the relevant data in a set of tabs
+			// within a tabset called "History"
+			$versions = $object->allVersions();
+			foreach($versions as $version) {
+				// Get a record of this version of the object
+				$record = self::get_version($object->ClassName, $object->ID, $version->Version);
 
-                // Make a set of read-only fields for use in assembling the History tabs
-                $read_fields = $current_tabs->makeReadonly();
+				// Make a set of read-only fields for use in assembling the History tabs
+				$read_fields = $current_tabs->makeReadonly();
 
-                // Make a form using the relevant fields and load it with data from this record
-                $form = new Form($object, "old_version", $read_fields, $object->getCMSActions());
-                $form->loadDataFrom($record);
+				// Make a form using the relevant fields and load it with data from this record
+				$form = new Form($object, "old_version", $read_fields, $object->getCMSActions());
+				$form->loadDataFrom($record);
 
-                // Add the version number to each field name so we don't have duplicate field names
-                if($form->fields->dataFields()) {
-                    foreach($form->fields->dataFields() as $field) {
-                        $field->Name = $field->Name . "version" . $version->Version;
-                    }
-                }
+				// Add the version number to each field name so we don't have duplicate field names
+				if($form->fields->dataFields()) {
+					foreach($form->fields->dataFields() as $field) {
+						$field->Name = $field->Name . "version" . $version->Version;
+					}
+				}
 
-                // Generate some heading strings describing this version
-                $was_published = $version->WasPublished ? "P" : "D";
-                $was_published_full = $version->WasPublished ? "Published" : "Saved as draft";
+				// Generate some heading strings describing this version
+				$was_published = $version->WasPublished ? "P" : "D";
+				$was_published_full = $version->WasPublished ? "Published" : "Saved as draft";
 
-                $publishedby = Member::get()->byId($version->PublisherID);
-                $authoredby = Member::get()->byId($version->AuthorID);
+				$publishedby = Member::get()->byId($version->PublisherID);
+				$authoredby = Member::get()->byId($version->AuthorID);
 
-                $publisher_heading = "";
-                $author_heading = "";
+				$publisher_heading = "";
+				$author_heading = "";
 
-                if($publishedby) {
-                    $publisher_heading = " by " . $publishedby->getName();
-                }
+				if($publishedby) {
+					$publisher_heading = " by " . $publishedby->getName();
+				}
 
-                if($authoredby) {
-                    $author_heading = " <em>authored by " . $authoredby->getName() . "</em>";
-                }
+				if($authoredby) {
+					$author_heading = " <em>authored by " . $authoredby->getName() . "</em>";
+				}
 
-                $up_date = new SS_Datetime('update');
-                $up_date->setValue($version->LastEdited);
+				$up_date = new SS_Datetime('update');
+				$up_date->setValue($version->LastEdited);
 
-                $nice_date = $up_date->FormatFromSettings();
-                $tab_title =  $nice_date . ' <span class="history-state">' . $was_published_full .  '</span> <span class="history-author">Author: ' . $authoredby ? $authoredby->getName() : 'N/A' . '</span>';
-                $latest_version_notice = "";
-                if($version->isLatestVersion()) {
-                    $latest_version_notice = " (latest version)";
-                }
-                $tab_heading = "<div class='message notice'><p><strong>Viewing version " . $version->Version . $latest_version_notice . ".</strong><br>" . $was_published_full . $publisher_heading . " on " . $nice_date . $author_heading . "</p></div>";
+				$nice_date = $up_date->FormatFromSettings();
+				$tab_title =  $nice_date . ' <span class="history-state">' . $was_published_full .  '</span> <span class="history-author">Author: ' . $authoredby ? $authoredby->getName() : 'N/A' . '</span>';
+				$latest_version_notice = "";
+				if($version->isLatestVersion()) {
+					$latest_version_notice = " (latest version)";
+				}
+				$tab_heading = "<div class='message notice'><p><strong>Viewing version " . $version->Version . $latest_version_notice . ".</strong><br>" . $was_published_full . $publisher_heading . " on " . $nice_date . $author_heading . "</p></div>";
 
-                // Add fields to a tab headed with a description of this version
-                $fields->addFieldsToTab('Root.History.' . $tab_title, LiteralField::create('versionHeader'.$version->Version, $tab_heading));
-                $fields->addFieldsToTab('Root.History.' . $tab_title, $form->fields);
-                // Add notice regarding untracked relationships
-                if($untracked_msg) {
-                    $fields->addFieldsToTab('Root.History.' . $tab_title, HeaderField::create('untrackedMessageHeader'.$version->Version, 'Note: the relationships listed below are not tracked in this view because they involve multiple records', 4));
-                    $fields->addFieldsToTab('Root.History.' . $tab_title, LiteralField::create('untrackedMessage'.$version->Version, $untracked_msg));
-                }
-            }
-        }
-        return $fields;
-    }
+				// Add fields to a tab headed with a description of this version
+				$fields->addFieldsToTab('Root.History.' . $tab_title, LiteralField::create('versionHeader'.$version->Version, $tab_heading));
+				$fields->addFieldsToTab('Root.History.' . $tab_title, $form->fields);
+				// Add notice regarding untracked relationships
+				if($untracked_msg) {
+					$fields->addFieldsToTab('Root.History.' . $tab_title, HeaderField::create('untrackedMessageHeader'.$version->Version, 'Note: the relationships listed below are not tracked in this view because they involve multiple records', 4));
+					$fields->addFieldsToTab('Root.History.' . $tab_title, LiteralField::create('untrackedMessage'.$version->Version, $untracked_msg));
+				}
+			}
+		}
+		return $fields;
+	}
 
-    /**
-     * Modified get_version query from Versioned core class
-     * - adapted to return the current class, rather than the baseDataClass
-     *
-     * Return the specific version of the given id.
-     *
-     * @param string $class
-     * @param int $id
-     * @param int $version
-     *
-     * @return DataObject
-     */
-    public static function get_version($class, $id, $version) {
-        $list = DataList::create($class)
-            ->where("\"$class\".\"RecordID\" = $id")
-            ->where("\"$class\".\"Version\" = " . (int)$version)
-            ->setDataQueryParam("Versioned.mode", 'all_versions');
+	/**
+	 * Modified get_version query from Versioned core class
+	 * - adapted to return the current class, rather than the baseDataClass
+	 *
+	 * Return the specific version of the given id.
+	 *
+	 * @param string $class
+	 * @param int $id
+	 * @param int $version
+	 *
+	 * @return DataObject
+	 */
+	public static function get_version($class, $id, $version) {
+		$list = DataList::create($class)
+			->where("\"$class\".\"RecordID\" = $id")
+			->where("\"$class\".\"Version\" = " . (int)$version)
+			->setDataQueryParam("Versioned.mode", 'all_versions');
 
-        return $list->First();
-    }
+		return $list->First();
+	}
 }

--- a/code/VersionViewerDataObject.php
+++ b/code/VersionViewerDataObject.php
@@ -115,7 +115,7 @@ class VersionViewerDataObject extends DataExtension
 				if($authoredby) {
 					$author_heading = " <em>authored by " . $authoredby->getName() . "</em>";
 					$tab_title = $nice_date . ' <span class="history-state">' . $was_published_full .  '</span> <span class="history-author">Author: ' . $authoredby->getName() . '</span>';
-				else {
+				} else {
 					$author_heading = "";
 					$tab_title = $nice_date . ' <span class="history-state">' . $was_published_full .  '</span>';
 				}

--- a/code/VersionViewerDataObject.php
+++ b/code/VersionViewerDataObject.php
@@ -1,7 +1,7 @@
 <?php
 
-class VersionViewerDataObject extends DataExtension {
-
+class VersionViewerDataObject extends DataExtension
+{
     public function addVersionViewer(FieldList $fields) {
         if($this->owner->hasExtension('Versioned') || $this->owner->hasExtension('VersionedDataObject')) {
             // Get the object where this function was called for reference purposes
@@ -10,11 +10,13 @@ class VersionViewerDataObject extends DataExtension {
             // Get all tabs in the current model admin and prepart to put within a tabset called "Current"
             $current_tabs = $fields->find('Name', 'Root')->Tabs();
             $fields = FieldList::create(
-                TabSet::create("Root",
+                $top = TabSet::create("Root",
                     $currenttab = TabSet::create("Current"),
                     $historytab = TabSet::create("History")->addExtraClass("vertical-tabs")
                 )
             );
+
+            $top->addExtraClass('tab-versioned');
 
             // Add all existing tabs to "Current" tabset
             $first = true;
@@ -42,7 +44,6 @@ class VersionViewerDataObject extends DataExtension {
                     }
                 }
             }
-                 // die();
 
 
             // Also, as of now, Versioned does not track has_many or many_many relationships
@@ -107,14 +108,14 @@ class VersionViewerDataObject extends DataExtension {
                 }
 
                 if($authoredby) {
-                    $author_heading = " (Authored by " . $authoredby->getName() . ")";
+                    $author_heading = " <em>authored by " . $authoredby->getName() . "</em>";
                 }
 
                 $up_date = new SS_Datetime('update');
                 $up_date->setValue($version->LastEdited);
 
                 $nice_date = $up_date->FormatFromSettings();
-                $tab_title = $version->Version . " - " . $nice_date . " (" . $was_published . ")";
+                $tab_title =  $nice_date . ' <span class="history-state">' . $was_published_full .  '</span> <span class="history-author">Author: ' . $authoredby->getName() . '</span>';
                 $latest_version_notice = "";
                 if($version->isLatestVersion()) {
                     $latest_version_notice = " (latest version)";
@@ -126,9 +127,8 @@ class VersionViewerDataObject extends DataExtension {
                 $fields->addFieldsToTab('Root.History.' . $tab_title, $form->fields);
                 // Add notice regarding untracked relationships
                 if($untracked_msg) {
-                    $fields->addFieldsToTab('Root.History.' . $tab_title, HeaderField::create('untrackedMessageHeader'.$version->Version, 'Note: the relationships listed below are not tracked by versioning because they involve multiple records', 4));
+                    $fields->addFieldsToTab('Root.History.' . $tab_title, HeaderField::create('untrackedMessageHeader'.$version->Version, 'Note: the relationships listed below are not tracked in this view because they involve multiple records', 4));
                     $fields->addFieldsToTab('Root.History.' . $tab_title, LiteralField::create('untrackedMessage'.$version->Version, $untracked_msg));
-                    // $fields->addFieldsToTab('Root.History.' . $tab_title, LiteralField::create('untrackedMessage'.$version->Version, $untracked_msg));
                 }
             }
         }

--- a/code/VersionViewerDataObject.php
+++ b/code/VersionViewerDataObject.php
@@ -1,11 +1,9 @@
 <?php
 
-class VersionViewerDataObject extends DataExtension
-{
+class VersionViewerDataObject extends DataExtension {
 
-    public function addVersionViewer(FieldList $fields)
-    {
-        if ($this->owner->hasExtension('Versioned') || $this->owner->hasExtension('VersionedDataObject')) {
+    public function addVersionViewer(FieldList $fields) {
+        if($this->owner->hasExtension('Versioned') || $this->owner->hasExtension('VersionedDataObject')) {
             // Get the object where this function was called for reference purposes
             $object = $this->owner;
 
@@ -20,11 +18,11 @@ class VersionViewerDataObject extends DataExtension
 
             // Add all existing tabs to "Current" tabset
             $first = true;
-            foreach ($current_tabs as $tab) {
+            foreach($current_tabs as $tab) {
                 // If we have the getVersionedState function,
                 // add a notice regarding the versioned state to the first tab
                 // TODO incorporate VersionedDataObjectState extension into this module
-                if ($first && $object->hasMethod('getVersionedState')) {
+                if($first && $object->hasMethod('getVersionedState')) {
                     $fields->addFieldToTab("Root.Current." . $tab->title,
                         LiteralField::create('VersionedState',
                             '<div class="message notice"><p>' . $object->getVersionedState() . '</p></div>'
@@ -36,10 +34,10 @@ class VersionViewerDataObject extends DataExtension
             }
 
             // Remove any fields that have VersionViewerVisibility turned off
-            foreach ($current_tabs as &$tab) {
-                foreach ($tab->Fields() as $field) {
+            foreach($current_tabs as &$tab) {
+                foreach($tab->Fields() as $field) {
                     // echo '<pre>'.$field->Name.' Viewable? '; print_r($field->versionViewerVisibility);
-                    if (!$field->versionViewerVisibility && $tab->fieldByName($field->Name)) {
+                    if(!$field->versionViewerVisibility && $tab->fieldByName($field->Name)) {
                         $tab->removeByName($field->Name);
                     }
                 }
@@ -51,14 +49,14 @@ class VersionViewerDataObject extends DataExtension
             // So find fields relating to those relationships, remove them,
             // and add a message regarding this
             $untracked_msg = "";
-            foreach ($current_tabs as &$tab) {
-                foreach ($tab->Fields() as $field) {
+            foreach($current_tabs as &$tab) {
+                foreach($tab->Fields() as $field) {
                     $rel_class = $object->getRelationClass($field->Name);
-                    if ($rel_class) {
-                        if (in_array($rel_class, $object->has_many()) || in_array($rel_class, $object->many_many())) {
-                            if ($tab->fieldByName($field->Name)) {
+                    if($rel_class) {
+                        if(in_array($rel_class, $object->has_many()) || in_array($rel_class, $object->many_many())) {
+                            if($tab->fieldByName($field->Name)) {
                                 $tab->removeByName($field->Name);
-                                if (!$untracked_msg) {
+                                if(!$untracked_msg) {
                                     // $untracked_msg = '<div class="message notice"><p>Note: the following relationships are not tracked by versioning because they involve multiple records:<br />';
                                     $untracked_msg = '<p>' . $field->Title();
                                 } else {
@@ -69,16 +67,16 @@ class VersionViewerDataObject extends DataExtension
                     }
                 }
             }
-            if ($untracked_msg) {
+            if($untracked_msg) {
                 $untracked_msg .= '</p>';
             }
 
             // Get all past versions of this data object and put the relevant data in a set of tabs
             // within a tabset called "History"
             $versions = $object->allVersions();
-            foreach ($versions as $version) {
+            foreach($versions as $version) {
                 // Get a record of this version of the object
-                $record = Versioned::get_version($object->ClassName, $object->ID, $version->Version);
+                $record = self::get_version($object->ClassName, $object->ID, $version->Version);
 
                 // Make a set of read-only fields for use in assembling the History tabs
                 $read_fields = $current_tabs->makeReadonly();
@@ -88,8 +86,8 @@ class VersionViewerDataObject extends DataExtension
                 $form->loadDataFrom($record);
 
                 // Add the version number to each field name so we don't have duplicate field names
-                if ($form->fields->dataFields()) {
-                    foreach ($form->fields->dataFields() as $field) {
+                if($form->fields->dataFields()) {
+                    foreach($form->fields->dataFields() as $field) {
                         $field->Name = $field->Name . "version" . $version->Version;
                     }
                 }
@@ -104,11 +102,11 @@ class VersionViewerDataObject extends DataExtension
                 $publisher_heading = "";
                 $author_heading = "";
 
-                if ($publishedby) {
+                if($publishedby) {
                     $publisher_heading = " by " . $publishedby->getName();
                 }
 
-                if ($authoredby) {
+                if($authoredby) {
                     $author_heading = " (Authored by " . $authoredby->getName() . ")";
                 }
 
@@ -118,7 +116,7 @@ class VersionViewerDataObject extends DataExtension
                 $nice_date = $up_date->FormatFromSettings();
                 $tab_title = $version->Version . " - " . $nice_date . " (" . $was_published . ")";
                 $latest_version_notice = "";
-                if ($version->isLatestVersion()) {
+                if($version->isLatestVersion()) {
                     $latest_version_notice = " (latest version)";
                 }
                 $tab_heading = "<div class='message notice'><p><strong>Viewing version " . $version->Version . $latest_version_notice . ".</strong><br>" . $was_published_full . $publisher_heading . " on " . $nice_date . $author_heading . "</p></div>";
@@ -127,7 +125,7 @@ class VersionViewerDataObject extends DataExtension
                 $fields->addFieldsToTab('Root.History.' . $tab_title, LiteralField::create('versionHeader'.$version->Version, $tab_heading));
                 $fields->addFieldsToTab('Root.History.' . $tab_title, $form->fields);
                 // Add notice regarding untracked relationships
-                if ($untracked_msg) {
+                if($untracked_msg) {
                     $fields->addFieldsToTab('Root.History.' . $tab_title, HeaderField::create('untrackedMessageHeader'.$version->Version, 'Note: the relationships listed below are not tracked by versioning because they involve multiple records', 4));
                     $fields->addFieldsToTab('Root.History.' . $tab_title, LiteralField::create('untrackedMessage'.$version->Version, $untracked_msg));
                     // $fields->addFieldsToTab('Root.History.' . $tab_title, LiteralField::create('untrackedMessage'.$version->Version, $untracked_msg));
@@ -135,5 +133,26 @@ class VersionViewerDataObject extends DataExtension
             }
         }
         return $fields;
+    }
+
+    /**
+     * Modified get_version query from Versioned core class
+     * - adapted to return the current class, rather than the baseDataClass
+     *
+     * Return the specific version of the given id.
+     *
+     * @param string $class
+     * @param int $id
+     * @param int $version
+     *
+     * @return DataObject
+     */
+    public static function get_version($class, $id, $version) {
+        $list = DataList::create($class)
+            ->where("\"$class\".\"RecordID\" = $id")
+            ->where("\"$class\".\"Version\" = " . (int)$version)
+            ->setDataQueryParam("Versioned.mode", 'all_versions');
+
+        return $list->First();
     }
 }

--- a/code/VersionViewerDataObject.php
+++ b/code/VersionViewerDataObject.php
@@ -115,7 +115,7 @@ class VersionViewerDataObject extends DataExtension
                 $up_date->setValue($version->LastEdited);
 
                 $nice_date = $up_date->FormatFromSettings();
-                $tab_title =  $nice_date . ' <span class="history-state">' . $was_published_full .  '</span> <span class="history-author">Author: ' . $authoredby->getName() . '</span>';
+                $tab_title =  $nice_date . ' <span class="history-state">' . $was_published_full .  '</span> <span class="history-author">Author: ' . $authoredby ? $authoredby->getName() : 'N/A' . '</span>';
                 $latest_version_notice = "";
                 if($version->isLatestVersion()) {
                     $latest_version_notice = " (latest version)";

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,11 +1,76 @@
 .tab-content {
 	border-top: 1px solid #c0c0c2;
 	clear: both;
+	height: 100%;
+}
+
+.vertical-tabs .ui-tabs-nav[style="display: none;"] + .tab-content {
+	padding-left:0;
+}
+
+.ss-tabset.tabset.tab-versioned .tab-content .ss-tabset {
+	padding:0;
+}
+
+.ss-tabset.tabset.tab-versioned .tab-content .ss-tabset .ui-tabs-panel {
+	padding-left: 40px;
+	padding-right: 40px;
 }
 
 .ui-tabs .vertical-tabs {
 	position:relative;
 }
+
+.tab-versioned.ui-tabs > .ui-tabs-nav {
+	margin-top: 0;
+	border-left: 1px solid #b3b3b3;
+}
+
+.tab-versioned.ui-tabs > .ui-tabs-nav .tabset {
+	border-top: 0;
+	margin:0;
+	border-radius: 0;
+	line-height: 39px;
+	display: inline-block;
+	vertical-align: middle;
+	float: left;
+	font-weight: bold;
+	color: #444;
+	line-height: 40px;
+	padding: 0;
+}
+
+
+.tab-versioned.ui-tabs > .ui-tabs-nav .tabset.ui-state-default {
+	-moz-box-shadow: rgba(201, 205, 206, 0.8) 0 0 2px;
+	-webkit-box-shadow: rgba(201, 205, 206, 0.8) 0 0 2px;
+	box-shadow: rgba(201, 205, 206, 0.8) 0 0 2px;
+	background-color: #b0bec7;
+	background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgi…pZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+	background-size: 100%;
+	background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #d4dbe0), color-stop(100%, #b0bec7));
+	background-image: -moz-linear-gradient(#d4dbe0, #b0bec7);
+	background-image: -webkit-linear-gradient(#d4dbe0, #b0bec7);
+	background-image: linear-gradient(#d4dbe0, #b0bec7);
+	border-right-color: #8399a7;
+	border-left-color: #ced7dc;
+}
+
+
+.tab-versioned.ui-tabs > .ui-tabs-nav .tabset.ui-state-active {
+	box-shadow: none;
+	background: #e6eaed;
+	border-top: none;
+	border-right-color: #b3b3b3;
+	border-left-color: #ECEFF1;
+	z-index: 2;
+}
+
+
+.ui-tabs .vertical-tabs {
+	height: 100%;
+}
+
 
 .vertical-tabs > .ui-tabs-nav {
 	background:#eceff1;
@@ -40,15 +105,34 @@
 	border-bottom:1px solid #c0c0c2 !important;
 }
 
+
+.vertical-tabs > .ui-tabs-nav > .ui-state-default {
+	background: transparent;
+}
+
 .vertical-tabs > .ui-tabs-nav > .ui-state-active {
 	border-right-color:#eceff1 !important;
+	color: #fff;
+	background: #338DC1;
 }
+
+.vertical-tabs > .ui-tabs-nav > .ui-state-active a {
+	color: #fff;
+	text-shadow: none;
+}
+
 
 .vertical-tabs > .ui-tabs-nav > li a {
 	background:transparent;
 	border:0;
 	display:block;
 	outline:none;
+	font-weight: normal;
+	line-height: 1.7em;
+	padding-top: 5px;
+	padding-bottom: 5px;
+	font-size: 0.8em;
+	text-transform: uppercase;
 }
 
 .vertical-tabs > .tab-content {
@@ -72,4 +156,40 @@
 	-webkit-border-radius:4px;
 	border-radius:4px;
 	padding:15px;
+}
+
+
+.cms-content-fields > fieldset {
+	height: 94%;
+	height: calc(100% - 40px);
+}
+
+.tabset.tab-versioned {
+	height: 100%;
+}
+.ss-tabset.tabset.tab-versioned  {
+	background: #E1E3E4;
+	padding:0;
+	border-top: 1px solid #b3b3b3; /* needs for when success/error message appears */
+	margin-top: -1px;
+	border-radius: 0;
+}
+
+.ss-tabset.tabset.tab-versioned .tab-content {
+	background: #e6eaed;
+}
+
+[style="display: none;"] + .tab-content {
+	border-top: 0;
+}
+
+
+.history-state {
+	font-size: 0.9em;
+	padding-left:20px;
+	float: right;
+}
+
+.history-author {
+	display:block;
 }


### PR DESCRIPTION
## FIX: Get data from current data object, not ancestor

get_version in the core Version object uses the baseDataClass to generate records, meaning that any fields added on descendent records appear blank in the history tab. There doesn't appear to be an option on version that uses the current class, rather than the base class. I've copied get version and altered it to look at the current class
## History view display adjustments

Now shows data of version, author, and status as a full word. I've also adjusted the css. See screen shots:

![versioned](https://cloud.githubusercontent.com/assets/984753/11770226/b862da50-a25d-11e5-8bb7-1aced1867eea.png)

![versioned_2](https://cloud.githubusercontent.com/assets/984753/11770230/c5dda94e-a25d-11e5-9a9a-e7602072b9a5.png)
